### PR TITLE
Make note of alternate uart port name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ B+ and Zero. This is not the configuration for the Raspberry Pi 2 or 3.
 | GPIO, I2C, SPI       | Yes - Elixir ALE                |
 | ADC                  | No                              |
 | PWM                  | Yes, but no Elixir support      |
-| UART                 | 1 available - ttyACM0           |
+| UART                 | 1 available - `ttyACM0` (called `ttyAMA0` on B and Zero)           |
 | Camera               | Yes - via rpi-userland          |
 | Ethernet             | Yes                             |
 | WiFi                 | Requires USB WiFi dongle        |


### PR DESCRIPTION
On the Pi B and Pi Zero, I found that the port name is `ttyAMA0`.  I am not sure about the other models, so I left `ttyACM0` in there as well.