### PR TITLE
Do not lock nerves dependency to 0.4.0 patch level

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule NervesSystemRpi.Mixfile do
   end
 
   defp deps do
-    [{:nerves, "0.4.0"},
+    [{:nerves, "~> 0.4.0"},
      {:nerves_system_br, "~> 0.8.1"},
      {:nerves_toolchain_armv6_rpi_linux_gnueabi, "~> 0.8.0"}]
   end


### PR DESCRIPTION
Currently, I'm unable to require nerves_system_rpi in a new nerves project (in nerves 0.4.1) due to the strict version requirement.