### PR TITLE
Reboot on exits now that bootloader catches most issues

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -22,7 +22,7 @@
 
 # Uncomment to hang the board rather than rebooting when Erlang exits
 # NOTE: Do not enable on production boards
---hang-on-exit
+#--hang-on-exit
 
 # Change the graceful shutdown time. If 10 seconds isn't long enough between
 # calling "poweroff", "reboot", or "halt" and :init.stop/0 stopping all OTP


### PR DESCRIPTION
Hanging on exit used to be really useful when outputing to the HDMI port
(the current default) so that you could capture errors. Now that
bootloader is around, it catches application issues for those not
updating to use a serial port or running over Ethernet. Switching this
behavior is useful for the hardware regression tests to keep them from
hanging.