### PR TITLE
Fix typo in config.txt

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -13,7 +13,7 @@ kernel=zImage
 # Disable the boot rainbow
 disable_splash=1
 
-# This, along with the Raspberry Pi "x" firmware is need for the camera
+# This, along with the Raspberry Pi "x" firmware is needed for the camera
 # to work. The Raspberry Pi "x" firmware is selected via the Buildroot
 # configuration. See Target packages->Hardware handling->Firmware.
 gpu_mem=192


### PR DESCRIPTION
This fixes a small typo in config.txt. This is the same change as proposed in https://github.com/nerves-project/nerves_system_rpi0/pull/82.