### PR TITLE
Enable delta update support

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -296,7 +296,11 @@ task upgrade.a {
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
     on-resource pi3-miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/pi3-miniuart-bt.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
-    on-resource rootfs.img { raw_write(${ROOTFS_A_PART_OFFSET}) }
+    on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_B_PART_COUNT}
+        raw_write(${ROOTFS_A_PART_OFFSET})
+    }
 
     on-finish {
         # Update firmware metadata
@@ -363,7 +367,11 @@ task upgrade.b {
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
     on-resource pi3-miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/pi3-miniuart-bt.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo") }
-    on-resource rootfs.img { raw_write(${ROOTFS_B_PART_OFFSET}) }
+    on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_A_PART_COUNT}
+        raw_write(${ROOTFS_B_PART_OFFSET})
+    }
 
     on-finish {
         # Update firmware metadata


### PR DESCRIPTION
This adds the information needed to the fwup.conf to support delta
updates. This is only one piece of delta update support. NervesHub can
automatically generate and distribute delta updates so long as it has a
copy of a device's firmware (a source firmware image) and the device is
running a version of fwup (1.6.0 or later; this is in nerves_system_br
1.11.2/May 2020 and later) that supports delta updates.