### PR TITLE
Add experimental env key for zigler and other tools

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,15 @@ defmodule NervesSystemRpi.MixProject do
       platform_config: [
         defconfig: "nerves_defconfig"
       ],
+      # The :env key is an optional experimental feature for adding environment
+      # variables to the crosscompile environment. These are intended for
+      # llvm-based tooling that may need more precise processor information.
+      env: [
+        {"TARGET_ARCH", "arm"},
+        {"TARGET_CPU", "arm1176jzf_s"},
+        {"TARGET_OS", "linux"},
+        {"TARGET_ABI", "gnueabi"}
+      ],
       checksum: package_files()
     ]
   end


### PR DESCRIPTION
The :env key is an optional experimental feature for adding environment
variables to the crosscompile environment. These are intended for
llvm-based tooling that may need more precise processor information.

This requires a Nerves version after 1.7.3.