### PR TITLE
Update CI to use new Buildroot dl cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,24 @@ exec: &exec
 version: 2.1
 
 orbs:
-  build-tools: nerves-project/build-tools@0.1.5
+  build-tools: nerves-project/build-tools@0.2.1
 
 workflows:
   version: 2
   build_test_deploy:
     jobs:
+      - build-tools/get-br-dependencies:
+          exec:
+            <<: *exec
+          context: org-global
+          push-to-download-site: true
       - build-tools/build-system:
           exec:
             <<: *exec
           resource-class: large
           context: org-global
+          requires:
+            - build-tools/get-br-dependencies
           filters:
             tags:
               only: /.*/

--- a/nerves_defconfig
+++ b/nerves_defconfig
@@ -1,6 +1,7 @@
 BR2_arm=y
 BR2_arm1176jzf_s=y
 BR2_TAR_OPTIONS="--no-same-owner"
+BR2_BACKUP_SITE="http://dl.nerves-project.org"
 BR2_ENABLE_DEBUG=y
 BR2_OPTIMIZE_2=y
 BR2_GLOBAL_PATCH_DIR="${BR2_EXTERNAL_NERVES_PATH}/patches"


### PR DESCRIPTION
- Update CI to use new method of caching Buildroot dependencies
- Use Nerves download site as backup
