### PR TITLE
Include dtb for the original RPi CM module

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -37,6 +37,9 @@ file-resource bcm2708-rpi-b.dtb {
 file-resource bcm2708-rpi-b-plus.dtb {
     host-path = "${NERVES_SYSTEM}/images/bcm2708-rpi-b-plus.dtb"
 }
+file-resource bcm2708-rpi-cm.dtb {
+    host-path = "${NERVES_SYSTEM}/images/bcm2708-rpi-cm.dtb"
+}
 file-resource w1-gpio-pullup.dtbo {
     host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pullup.dtbo"
 }
@@ -167,6 +170,7 @@ task complete {
     on-resource bcm2708-rpi-zero.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-zero.dtb") }
     on-resource bcm2708-rpi-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-b.dtb") }
     on-resource bcm2708-rpi-b-plus.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-b-plus.dtb") }
+    on-resource bcm2708-rpi-cm.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-cm.dtb") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
@@ -239,6 +243,7 @@ task upgrade.a {
     on-resource bcm2708-rpi-zero.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-zero.dtb") }
     on-resource bcm2708-rpi-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-b.dtb") }
     on-resource bcm2708-rpi-b-plus.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-b-plus.dtb") }
+    on-resource bcm2708-rpi-cm.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-cm.dtb") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
@@ -319,6 +324,7 @@ task upgrade.b {
     on-resource bcm2708-rpi-zero.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-zero.dtb") }
     on-resource bcm2708-rpi-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-b.dtb") }
     on-resource bcm2708-rpi-b-plus.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-b-plus.dtb") }
+    on-resource bcm2708-rpi-cm.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-cm.dtb") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource ramoops.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo") }


### PR DESCRIPTION
This fixes support for the original Revolution Pi.
