### PR TITLE
Add delta update support for boot partition files

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -3,7 +3,7 @@
 # IMPORTANT:
 # Edit `fwup.conf.eex` and run `mix generate_fwup_conf` to generate fwup.conf.
 #
-require-fwup-version="1.0.0"
+require-fwup-version="1.12.0"
 
 include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
@@ -328,25 +328,101 @@ task upgrade.a {
     # to the B partition, so an error or power failure during this part
     # won't hurt anything.
     on-resource cmdline-a.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource start.elf { fat_write(${BOOT_A_PART_OFFSET}, "start.elf") }
-    on-resource fixup.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat") }
-    on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
-    on-resource zImage { fat_write(${BOOT_A_PART_OFFSET}, "zImage") }
-    on-resource bcm2708-rpi-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-b.dtb") }
-    on-resource bcm2708-rpi-b-plus.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-b-plus.dtb") }
-    on-resource bcm2708-rpi-cm.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-cm.dtb") }
-    on-resource bcm2708-rpi-zero.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-zero.dtb") }
-    on-resource bcm2708-rpi-zero-w.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-zero-w.dtb") }
-    on-resource overlays/i2c-mux.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
-    on-resource overlays/imx219.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo") }
-    on-resource overlays/imx296.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo") }
-    on-resource overlays/imx477.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo") }
-    on-resource overlays/imx708.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo") }
-    on-resource overlays/miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
-    on-resource overlays/ov5647.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo") }
-    on-resource overlays/ramoops.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo") }
-    on-resource overlays/tc358743.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo") }
-    on-resource overlays/w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource start.elf {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="start.elf"
+        fat_write(${BOOT_A_PART_OFFSET}, "start.elf")
+    }
+    on-resource fixup.dat {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="fixup.dat"
+        fat_write(${BOOT_A_PART_OFFSET}, "fixup.dat")
+    }
+    on-resource config.txt {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="config.txt"
+        fat_write(${BOOT_A_PART_OFFSET}, "config.txt")
+    }
+    on-resource zImage {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="zImage"
+        fat_write(${BOOT_A_PART_OFFSET}, "zImage")
+    }
+    on-resource bcm2708-rpi-b.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-b.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-b.dtb")
+    }
+    on-resource bcm2708-rpi-b-plus.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-b-plus.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-b-plus.dtb")
+    }
+    on-resource bcm2708-rpi-cm.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-cm.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-cm.dtb")
+    }
+    on-resource bcm2708-rpi-zero.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-zero.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-zero.dtb")
+    }
+    on-resource bcm2708-rpi-zero-w.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-zero-w.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2708-rpi-zero-w.dtb")
+    }
+    on-resource overlays/i2c-mux.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c-mux.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo")
+    }
+    on-resource overlays/imx219.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx219.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo")
+    }
+    on-resource overlays/imx296.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx296.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo")
+    }
+    on-resource overlays/imx477.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx477.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo")
+    }
+    on-resource overlays/imx708.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx708.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo")
+    }
+    on-resource overlays/miniuart-bt.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/miniuart-bt.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo")
+    }
+    on-resource overlays/ov5647.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/ov5647.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo")
+    }
+    on-resource overlays/ramoops.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/ramoops.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops.dtbo")
+    }
+    on-resource overlays/tc358743.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/tc358743.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo")
+    }
+    on-resource overlays/w1-gpio-pullup.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pullup.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo")
+    }
 
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
@@ -412,25 +488,101 @@ task upgrade.b {
     # to the A partition, so an error or power failure during this part
     # won't hurt anything.
     on-resource cmdline-b.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-    on-resource start.elf { fat_write(${BOOT_B_PART_OFFSET}, "start.elf") }
-    on-resource fixup.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup.dat") }
-    on-resource config.txt { fat_write(${BOOT_B_PART_OFFSET}, "config.txt") }
-    on-resource zImage { fat_write(${BOOT_B_PART_OFFSET}, "zImage") }
-    on-resource bcm2708-rpi-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-b.dtb") }
-    on-resource bcm2708-rpi-b-plus.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-b-plus.dtb") }
-    on-resource bcm2708-rpi-cm.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-cm.dtb") }
-    on-resource bcm2708-rpi-zero.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-zero.dtb") }
-    on-resource bcm2708-rpi-zero-w.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-zero-w.dtb") }
-    on-resource overlays/i2c-mux.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
-    on-resource overlays/imx219.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx219.dtbo") }
-    on-resource overlays/imx296.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx296.dtbo") }
-    on-resource overlays/imx477.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx477.dtbo") }
-    on-resource overlays/imx708.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx708.dtbo") }
-    on-resource overlays/miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
-    on-resource overlays/ov5647.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ov5647.dtbo") }
-    on-resource overlays/ramoops.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo") }
-    on-resource overlays/tc358743.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/tc358743.dtbo") }
-    on-resource overlays/w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource start.elf {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="start.elf"
+        fat_write(${BOOT_B_PART_OFFSET}, "start.elf")
+    }
+    on-resource fixup.dat {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="fixup.dat"
+        fat_write(${BOOT_B_PART_OFFSET}, "fixup.dat")
+    }
+    on-resource config.txt {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="config.txt"
+        fat_write(${BOOT_B_PART_OFFSET}, "config.txt")
+    }
+    on-resource zImage {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="zImage"
+        fat_write(${BOOT_B_PART_OFFSET}, "zImage")
+    }
+    on-resource bcm2708-rpi-b.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-b.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-b.dtb")
+    }
+    on-resource bcm2708-rpi-b-plus.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-b-plus.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-b-plus.dtb")
+    }
+    on-resource bcm2708-rpi-cm.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-cm.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-cm.dtb")
+    }
+    on-resource bcm2708-rpi-zero.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-zero.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-zero.dtb")
+    }
+    on-resource bcm2708-rpi-zero-w.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2708-rpi-zero-w.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2708-rpi-zero-w.dtb")
+    }
+    on-resource overlays/i2c-mux.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c-mux.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c-mux.dtbo")
+    }
+    on-resource overlays/imx219.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx219.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx219.dtbo")
+    }
+    on-resource overlays/imx296.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx296.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx296.dtbo")
+    }
+    on-resource overlays/imx477.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx477.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx477.dtbo")
+    }
+    on-resource overlays/imx708.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx708.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx708.dtbo")
+    }
+    on-resource overlays/miniuart-bt.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/miniuart-bt.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo")
+    }
+    on-resource overlays/ov5647.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/ov5647.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/ov5647.dtbo")
+    }
+    on-resource overlays/ramoops.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/ramoops.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops.dtbo")
+    }
+    on-resource overlays/tc358743.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/tc358743.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/tc358743.dtbo")
+    }
+    on-resource overlays/w1-gpio-pullup.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pullup.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo")
+    }
 
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}

--- a/fwup.conf.eex
+++ b/fwup.conf.eex
@@ -3,7 +3,7 @@
 # IMPORTANT:
 # Edit `fwup.conf.eex` and run `mix generate_fwup_conf` to generate fwup.conf.
 #
-require-fwup-version="1.0.0"
+require-fwup-version="1.12.0"
 
 include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
@@ -279,7 +279,11 @@ task upgrade.a {
     # to the B partition, so an error or power failure during this part
     # won't hurt anything.
     on-resource cmdline-a.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_A_PART_OFFSET}, "<%= resource.name %>") }
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="<%= resource.name %>"
+        fat_write(${BOOT_A_PART_OFFSET}, "<%= resource.name %>")
+    }
 <% end %>
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
@@ -345,7 +349,11 @@ task upgrade.b {
     # to the A partition, so an error or power failure during this part
     # won't hurt anything.
     on-resource cmdline-b.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_B_PART_OFFSET}, "<%= resource.name %>") }
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="<%= resource.name %>"
+        fat_write(${BOOT_B_PART_OFFSET}, "<%= resource.name %>")
+    }
 <% end %>
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}


### PR DESCRIPTION
cmdline.txt is excluded since the copy on the other boot partition is
the other slot's variant.

Bump require-fwup-version to 1.12.0.